### PR TITLE
chore: go 1.19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       - uses: goreleaser/goreleaser-action@v2.8.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
     - uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - uses: goreleaser/goreleaser-action@v2.8.0
       with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,9 +31,6 @@ builds:
         goarch: arm
       - goos: windows
         goarch: 386
-archives:
-  - replacements:
-      386: i386
 changelog:
   sort: asc
 # dockers:


### PR DESCRIPTION
remove goreleaser depricated options